### PR TITLE
Update to the TransitioningBackgrounds.plugin.js

### DIFF
--- a/TransitioningBackgrounds.plugin.js
+++ b/TransitioningBackgrounds.plugin.js
@@ -23,7 +23,7 @@ class TransitioningBackgrounds {
     getName() { return "Transitioning Backgrounds"; }
     getDescription() { return "Allows you to set a list of backgrounds that will be transitioned between with several transition types, in order, or at random."; }
     getVersion() { return "0.1.3"; }
-    getAuthor() { return "Metalloriff"; }
+    getAuthor() { return "Metalloriff, Fixed by Subaru#1337"; }
 
     load() {}
 

--- a/TransitioningBackgrounds.plugin.js
+++ b/TransitioningBackgrounds.plugin.js
@@ -22,7 +22,7 @@ class TransitioningBackgrounds {
 	
     getName() { return "Transitioning Backgrounds"; }
     getDescription() { return "Allows you to set a list of backgrounds that will be transitioned between with several transition types, in order, or at random."; }
-    getVersion() { return "0.1.3"; }
+    getVersion() { return "0.1.4"; }
     getAuthor() { return "Metalloriff, Fixed by Subaru#1337"; }
 
     load() {}

--- a/TransitioningBackgrounds.plugin.js
+++ b/TransitioningBackgrounds.plugin.js
@@ -414,7 +414,7 @@ class TransitioningBackgrounds {
                     background: rgba(0, 0, 0, ${this.settings.backgroundDarkness}) !important;
                 }
 
-                .layer-3QrUeG, .layers-3iHuyZ, .guilds-wrapper, .channels-Ie2l6A, .chat, .title-3qD0b-, .content, .messages-wrapper, .chat form, .sidebar-region, .content-region, .scroller-2FKFPG, .container-PNkimc, .container-PNkimc, #friends, .headerBar-UHpsPw, .friends-table, .typing-2GQL18 {
+                .layer-3QrUeG, .guildsWrapper-5TJh6A, .applicationStore-1pNvnv, .theme-dark .header-39GIC8, .gameUpdates-2GPqBU, .gameLibrary-TTDw4Y, .table-1tDS6w , .layers-3iHuyZ, .guilds-wrapper, .channels-Ie2l6A, .theme-dark .chat-3bRxxu, .title-3qD0b-, .theme-dark .content-yTz4x3, .theme-dark .messagesWrapper-3lZDfY, .theme-dark .chat-3bRxxu form, .sidebar-region, .content-region, .scroller-2FKFPG, .container-PNkimc, .container-PNkimc, #friends, .headerBar-UHpsPw, .friends-table, .theme-dark .activityFeed-28jde9, .typing-2GQL18 {
                     background: transparent !important;
                     background-color: transparent !important;
                 }


### PR DESCRIPTION
Makes the plugin usable again fixes the obnoxious transparency issue of the plugin where you only can see the background behind the channels and not the actual chat. so now you can actually see your background now. also adds support for backgrounds on the new pages such as store, activity, library and make the guild bar transparent i personally like it transparent some might not Sue me this plugin seems to be abandoned since this problem has been a thing for over 4 to 5 months but heres the fix if people still want to use it.