### PR TITLE
Fix SendBDEmotes by selecting the proper module to upload.

### DIFF
--- a/SendBDEmotes.plugin.js
+++ b/SendBDEmotes.plugin.js
@@ -65,7 +65,7 @@ class SendBDEmotes {
 		NeatoLib.Updates.check(this);
 
 		this.hasPermission = NeatoLib.Modules.get(["can"]).can;
-		this.uploadFile = NeatoLib.Modules.get(["upload"]).upload;
+		this.uploadFile = NeatoLib.Modules.findAllByPropertyName('upload')[1];
 		this.messageModule = NeatoLib.Modules.get(["sendMessage"]);
 
 		this.settings = NeatoLib.Settings.load(this);


### PR DESCRIPTION
SendBDEmotes has been recently broken by one of the major Discord updates. This happened due to the `uploadFile` function being incorrectly set to some CSS that used the same naming structure. ![](https://i.imgur.com/MCS65kl.png)
This prevented the image from actually being sent.

This commit selects the correct function to upload a file and fixes the plugin.