### PR TITLE
Update NeatoBurritoLibrary.js

### DIFF
--- a/Lib/NeatoBurritoLibrary.js
+++ b/Lib/NeatoBurritoLibrary.js
@@ -2353,7 +2353,7 @@ var NeatoLib = {
 
 	getClass: function(moduleName, className = moduleName, index = 0) {
 		let temp = NeatoLib.Modules.get(moduleName);
-		if(!temp) return;
+		if(!temp || typeof temp[className] !== "string") return;
 		if(!temp[className]) return temp[moduleName].split(" ")[index];
 		return temp[className].split(" ")[index];
 	},


### PR DESCRIPTION
getClass now ignores anything but string to prevent error (for example when it's getting a function)