### PR TITLE
Fix Uncaught TypeError

### DIFF
--- a/ShareButton.plugin.js
+++ b/ShareButton.plugin.js
@@ -95,7 +95,7 @@ class ShareButton {
         });
 
         setTimeout(() => {
-            if(document.getElementsByClassName("popouts-3dRSmE")) this.popoutObserver.observe(document.getElementsByClassName("popouts-3dRSmE")[0], { childList : true });
+            if(document.getElementsByClassName("popouts-3dRSmE").length != 0) this.popoutObserver.observe(document.getElementsByClassName("popouts-3dRSmE")[0], { childList : true });
         }, 5000);
 
         this.contextEvent = e => {


### PR DESCRIPTION
Fixes https://github.com/Metalloriff/BetterDiscordPlugins/issues/181
.getElementsByClassName Gives back an array and passes the If statement. 
We should check first to see if the array is empty before attempting to use it.