### PR TITLE
Made regional indicators always lowercase

### DIFF
--- a/TheClapBestClapPluginClapEver.plugin.js
+++ b/TheClapBestClapPluginClapEver.plugin.js
@@ -84,7 +84,7 @@ module.exports = (() =>
 								message.content = message.content.substr(ra[0].length, message.content.length)
 									.split(" ")
 									.join("\t")
-									.replace(/[A-Za-z]/g, x => ` :regional_indicator_${x}: `);
+									.replace(/[A-Za-z]/g, x => ` :regional_indicator_${x.toLowerCase()}: `);
 								
 								break;
 


### PR DESCRIPTION
Made regional indicators always lowercase to prevent an issue where if you type you message in uppercase it won't send valid emotes.