### PR TITLE
Fix GuildAndFriendRemovalAlerts initialize

### DIFF
--- a/GuildAndFriendRemovalAlerts.plugin.js
+++ b/GuildAndFriendRemovalAlerts.plugin.js
@@ -155,7 +155,7 @@ module.exports = (() =>
 			const { default: ContextMenu } = WebpackModules.getByProps("MenuStyle", "default");
 			const { MenuGroup: CtxMenuGroup, MenuItem: CtxMenuItem } = WebpackModules.find(m => m.MenuRadioItem && !m.default);
 
-			const { listRow, listRowContent, listName } = WebpackModules.getByProps("header", "botTag", "listAvatar");
+			const { listRow, listRowContent, listName } = WebpackModules.getByProps("listName", "listRow", "listAvatar");
 
 			class GuildItem extends React.Component
 			{

--- a/GuildAndFriendRemovalAlerts.plugin.js
+++ b/GuildAndFriendRemovalAlerts.plugin.js
@@ -433,46 +433,49 @@ module.exports = (() =>
 	
 				onStart()
 				{
-					this.loop = setInterval(() => this.tick(), 5000);
+					this.awaitLoad = setInterval(function(){
+						if(getCurrentUser()===undefined)return;
+						clearInterval(this.awaitLoad);
+						this.loop = setInterval(() => this.tick(), 5000);
+						this.removedGuildHistory = PluginUtilities.loadData(this.getDataName(), "removedGuildHistory", []);
+						this.removedFriendHistory = PluginUtilities.loadData(this.getDataName(), "removedFriendHistory", []);
 
-					this.removedGuildHistory = PluginUtilities.loadData(this.getDataName(), "removedGuildHistory", []);
-					this.removedFriendHistory = PluginUtilities.loadData(this.getDataName(), "removedFriendHistory", []);
-
-					ReactComponents.getComponentByName("DefaultHomeButton", "*").then(r =>
-					{
-						Patcher.after(r.component.prototype, "render", (props, args, re) =>
+						ReactComponents.getComponentByName("DefaultHomeButton", "*").then(r =>
 						{
-							re.props.onContextMenu = e =>
+							Patcher.after(r.component.prototype, "render", (props, args, re) =>
 							{
-								ContextMenuActions.openContextMenu(e, () =>
-									React.createElement(
-										ContextMenu,
-										{
-											navId: "HomeContextMenu",
-											onClose: ContextMenuActions.closeContextMenu,
-											children:
-											[
-												React.createElement(
-													CtxMenuGroup,
-													{
-														children:
-															React.createElement(
-																CtxMenuItem,
-																{
-																	label: "View GFR History",
-																	id: "view-gfr-history",
-																	action: () => this.openModal(this.removedGuildHistory, this.removedFriendHistory)
-																}
-															)
-													}
-												)
-											]
-										}
-									)
-								);
-							};
-						});
-					}).catch(exc => console.warn(this.getName() + ": Failed to patch react component 'DefaultHomeButton'. Reason: " + exc));
+								re.props.onContextMenu = e =>
+								{
+									ContextMenuActions.openContextMenu(e, () =>
+										React.createElement(
+											ContextMenu,
+											{
+												navId: "HomeContextMenu",
+												onClose: ContextMenuActions.closeContextMenu,
+												children:
+												[
+													React.createElement(
+														CtxMenuGroup,
+														{
+															children:
+																React.createElement(
+																	CtxMenuItem,
+																	{
+																		label: "View GFR History",
+																		id: "view-gfr-history",
+																		action: () => this.openModal(this.removedGuildHistory, this.removedFriendHistory)
+																	}
+																)
+														}
+													)
+												]
+											}
+										)
+									);
+								};
+							});
+						}).catch(exc => console.warn(this.getName() + ": Failed to patch react component 'DefaultHomeButton'. Reason: " + exc));
+					}.bind(this),1000);
 				}
 
 				tick()


### PR DESCRIPTION
It wasn't able to find the classes it needed anymore and broke. I checked the other pull request, #210 has the same issue atm. I tested that it was working beyond this by having a friend remove me and add me back. Meaning I do not know if there are any other issues, besides possibly #210, right now.