### PR TITLE
GuildAndFriendRemovalAlerts: Check for removals immediately on startup

### DIFF
--- a/GuildAndFriendRemovalAlerts/GuildAndFriendRemovalAlerts.plugin.js
+++ b/GuildAndFriendRemovalAlerts/GuildAndFriendRemovalAlerts.plugin.js
@@ -555,6 +555,7 @@ function buildPlugin([BasePlugin, PluginApi]) {
 						}));
 						external_StyleLoader_default().inject();
 						events.forEach((eventType => modules_namespaceObject.Dispatcher.subscribe(eventType, this.main)));
+						this.main();
 					}
 					serializeGuild(guildId) {
 						const serialized = {

--- a/GuildAndFriendRemovalAlerts/src/index.js
+++ b/GuildAndFriendRemovalAlerts/src/index.js
@@ -76,6 +76,7 @@ export default class GuildAndFriendRemovalAlerts extends BasePlugin {
 		stylesheet.inject();
 		
 		events.forEach(eventType => Dispatcher.subscribe(eventType, this.main));
+		this.main();
 	}
 	
 	serializeGuild(guildId) {


### PR DESCRIPTION
If a guild or friend removes you while you were offline, the plugin will not notify you until one of the dispatcher events is called.
With this change it will check immediately on plugin start.