### PR TITLE
[GuildAndFriendRemovalAlerts] patch-1.1 (based off patch-1 by example-git)

### DIFF
--- a/GuildAndFriendRemovalAlerts/GuildAndFriendRemovalAlerts.plugin.js
+++ b/GuildAndFriendRemovalAlerts/GuildAndFriendRemovalAlerts.plugin.js
@@ -161,7 +161,7 @@ function buildPlugin([BasePlugin, PluginApi]) {
 			},
 			'@discord/modules': {
 				get 'Dispatcher'() {
-					return ___createMemoize___(this, 'Dispatcher', () => BdApi.findModuleByProps('dirtyDispatch', 'subscribe'))
+					return ___createMemoize___(this, 'Dispatcher', () => BdApi.findModuleByProps('dispatch', 'subscribe'))
 				},
 				get 'ComponentDispatcher'() {
 					return ___createMemoize___(this, 'ComponentDispatcher', () => BdApi.findModuleByProps('ComponentDispatch')?.ComponentDispatch)

--- a/GuildAndFriendRemovalAlerts/GuildAndFriendRemovalAlerts.plugin.js
+++ b/GuildAndFriendRemovalAlerts/GuildAndFriendRemovalAlerts.plugin.js
@@ -456,7 +456,7 @@ function buildPlugin([BasePlugin, PluginApi]) {
 					getFriendIDs
 				} = external_PluginApi_namespaceObject.WebpackModules.getByProps("getFriendIDs");
 				const HomeButton = external_PluginApi_namespaceObject.WebpackModules.getByProps("HomeButton");
-				const events = [constants_namespaceObject.ActionTypes.GUILD_CREATE, constants_namespaceObject.ActionTypes.GUILD_DELETE, constants_namespaceObject.ActionTypes.GUILD_UPDATE, constants_namespaceObject.ActionTypes.RELATIONSHIP_ADD, constants_namespaceObject.ActionTypes.RELATIONSHIP_REMOVE, constants_namespaceObject.ActionTypes.RELATIONSHIP_UPDATE, constants_namespaceObject.ActionTypes.FRIEND_REQUEST_ACCEPTED];
+				const events = ["GUILD_CREATE", "GUILD_DELETE", "GUILD_UPDATE", "RELATIONSHIP_ADD", "RELATIONSHIP_REMOVE", "RELATIONSHIP_UPDATE", "FRIEND_REQUEST_ACCEPTED"];
 				class GuildAndFriendRemovalAlerts extends(external_BasePlugin_default()) {
 					constructor(...args) {
 						super(...args);


### PR DESCRIPTION
This patch extends the initial fix by
[example-git](https://github.com/Metalloriff/BetterDiscordPlugins/pull/252) which no longer works as of latest discord update on stable builds.
It does not completely address the issue with `unsubscribe` function on
line 656, possibly when stopping the script, it will however, function
otherwise when started.

A shout-out to [HypedDomi](https://github.com/HypedDomi) for their fix to
another plugin that
[gave clues](https://github.com/Strencher/BetterDiscordStuff/pull/242) on
addressing this.